### PR TITLE
feat: add support for LogRocket init() config

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,12 @@ npm install nuxt-logrocket --save
   ],
 
   logRocket: {
+    // configure LogRocket
     logRocketId: '',
     devModeAllowed: false,
+    config: {
+      //
+    }
   }
 }
 ```
@@ -91,18 +95,55 @@ You can read more about this integration [here](https://docs.logrocket.com/docs/
 Options can be passed using either environment variables or `logRocket` section in `nuxt.config.js`.
 Setting a value for the required `logRocketId` option is enough in most cases.
 
-### logRocketId
+Below is the complete list of options:
 
-- Type: `String`
-  - Default: `process.env.LOGROCKET_ID || ''`
-  - Required: `True`
+| Option | Type | Default | Required | Environment Variable |
+| :-- | :-- | :-- | :-- | :-- |
+| logRocketId | `String` | `''` | True | `process.env.LOGROCKET_ID` |
+| devModeAllowed | `Boolean` | `false` | False | `process.env.LOGROCKET_DEV_MODE_ALLOWED` |
+| release | `String` | `null` | False | `process.env.LOGROCKET_RELEASE` |
+| consoleEnabled | `Boolean` | `true` | False | `process.env.LOGROCKET_CONSOLE` |
+| networkEnabled | `Boolean` | `true` | False | `process.env.LOGROCKET_NETWORK` |
+| networkRequestSanitizer | `Function` | - | False | - |
+| networkResponseSanitizer | `Function` | - | False | - |
+| domEnabled | `Boolean` | `true` | False | `process.env.LOGROCKET_DOM_ENABLED` |
+| inputSanitizer | `Boolean` | `false` | False | `process.env.LOGROCKET_INPUT_SANITIZER` |
+| textSanitizer | `Boolean` | `false` | False | `process.env.LOGROCKET_TEXT_SANITIZER` |
+| baseHref | `String` | `null` | False | `process.env.LOGROCKET_BASE_HREF` |
+| shouldCaptureIP | `Boolean` | `true` | False | `process.env.LOGROCKET_SHOULD_CAPTURE_IP` |
+| rootHostname | `String` | `null` | False | `process.env.LOGROCKET_ROOT_HOSTNAME` |
+| shouldDebugLog | `Boolean` | `true` | False | `process.env.LOGROCKET_SHOULD_DEBUG_LOG` |
+| mergeIframes | `Boolean` | `false` | False | `process.env.LOGROCKET_MERGE_IFRAMES` |
 
-### devModeAllowed
+This is an example containing the default values for the options:
 
-- Type: `Boolean`
-  - Default: `process.env.LOGROCKET_DEV_MODE_ALLOWED || false`
-  - Required: `False`
-
+```js
+{
+  logRocketId: '',
+  devModeAllowed: false,
+  config: {
+    release: null,
+    console: {
+      isEnabled: true
+    },
+    network: {
+      isEnabled: true,
+      networkRequestSanitizer: () => {},
+      networkResponseSanitizer: () => {}
+    },
+    dom: {
+      isEnabled: true,
+      inputSanitizer: false,
+      textSanitizer: false,
+      baseHref: null
+    },
+    shouldCaptureIP: true,
+    rootHostname: null,
+    shouldDebugLog: true,
+    mergeIframes: false
+  }
+}
+```
 
 ## Usage
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,11 +1,31 @@
 const { resolve } = require('path')
+const merge = require('deepmerge')
 
 module.exports = async function module (moduleOptions) {
-  const options = Object.assign(
+  const options = merge(
     // default options
     {
       logRocketId: process.env.LOGROCKET_ID || '',
-      devModeAllowed: process.env.LOGROCKET_DEV_MODE_ALLOWED || false
+      devModeAllowed: process.env.LOGROCKET_DEV_MODE_ALLOWED || false,
+      config: {
+        release: process.env.LOGROCKET_RELEASE || null,
+        console: {
+          isEnabled: process.env.LOGROCKET_CONSOLE || true
+        },
+        network: {
+          isEnabled: process.env.LOGROCKET_NETWORK || true
+        },
+        dom: {
+          isEnabled: process.env.LOGROCKET_DOM_ENABLED || true,
+          inputSanitizer: process.env.LOGROCKET_INPUT_SANITIZER || false,
+          textSanitizer: process.env.LOGROCKET_TEXT_SANITIZER || false,
+          baseHref: process.env.LOGROCKET_BASE_HREF || null
+        },
+        shouldCaptureIP: process.env.LOGROCKET_SHOULD_CAPTURE_IP || true,
+        rootHostname: process.env.LOGROCKET_ROOT_HOSTNAME || null,
+        shouldDebugLog: process.env.LOGROCKET_SHOULD_DEBUG_LOG || true,
+        mergeIframes: process.env.LOGROCKET_MERGE_IFRAMES || false
+      }
     },
     this.options.logRocket,
     moduleOptions

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -3,6 +3,7 @@ import createPlugin from 'logrocket-vuex';
 
 const LOGROCKET_ID = '<%= options.logRocketId %>'
 const DEV_MODE_ALLOWED = <%= options.devModeAllowed %>
+const CONFIG = <%= serialize(options.config) %>
 
 export default function ({ app, store }, inject) {
     try {
@@ -12,7 +13,7 @@ export default function ({ app, store }, inject) {
         // or when the developer enables devModeAllowed
         if (LOGROCKET_ID && ((process.client && isProduction) || DEV_MODE_ALLOWED)) {
             // initialize LogRocket with the provided id
-            LogRocket.init(LOGROCKET_ID);
+            LogRocket.init(LOGROCKET_ID, CONFIG);
 
             // if nuxt app has a store initialized, load the logrocket-vuex plugin
             if (store) {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "standard-version": "^9.0.0"
   },
   "dependencies": {
+    "deepmerge": "^4.2.2",
     "logrocket": "^1.0.14",
     "logrocket-vuex": "^0.0.3"
   }


### PR DESCRIPTION
Closes #63 

This merge request adds support for configuring the LogRocket `init()` function.

The original documentation can be found here: [https://docs.logrocket.com/reference#init](https://docs.logrocket.com/reference#init)